### PR TITLE
Harmonize docstrings and cleanup imports

### DIFF
--- a/video_embedding/augmentation.py
+++ b/video_embedding/augmentation.py
@@ -1,5 +1,3 @@
-"""Video augmentation for self-supervised learning."""
-
 import numpy as np
 import albumentations as A
 from scipy.ndimage import gaussian_filter1d
@@ -46,8 +44,7 @@ def translate(image: np.ndarray, shift_x: int, shift_y: int) -> np.ndarray:
 def apply_albumentations_to_video(
     video_array: np.ndarray, alb_transform: A.ReplayCompose
 ) -> np.ndarray:
-    """
-    Implement albumentations ReplayCompose transformation across all frames in video sequence.
+    """Apply augmentations consistently to all frames of a video.
 
     Args:
         video_array: Video as array of frames.
@@ -69,8 +66,7 @@ def apply_albumentations_to_video(
 
 
 def center_crop(video_array: np.ndarray, crop_size: int) -> np.ndarray:
-    """
-    Crop video around its center to a fixed size.
+    """Crop video around its center to a fixed size.
 
     Args:
         video_array: Video as array of frames.
@@ -91,8 +87,7 @@ def center_crop(video_array: np.ndarray, crop_size: int) -> np.ndarray:
 
 
 def random_temporal_crop(video_array: np.ndarray, duration: int) -> np.ndarray:
-    """
-    Crop video randomly along temporal axis to a fixed frame count.
+    """Crop video randomly along temporal axis to a fixed frame count.
 
     Args:
         video_array: Video as array of frames.
@@ -114,8 +109,7 @@ def random_drift(
     gaussian_kernel: int,
     multiplier: float,
 ) -> np.ndarray:
-    """
-    Augment a video with random camera drift.
+    """Augment a video with random camera drift.
 
     Args:
         video_array: Input video.
@@ -147,8 +141,7 @@ class VideoClipAugmentator:
         multiplier=6,
         dof=1.5,
     ):
-        """Initialize the augmentator with default augmentation parameters.
-
+        """
         Args:
             duration: Number of frames to keep after cropping temporally.
             crop_size: Spatial crop size applied at the end of the pipeline.

--- a/video_embedding/io.py
+++ b/video_embedding/io.py
@@ -1,25 +1,19 @@
 """Video reader for self-supervised learning."""
 
 import numpy as np
-import cv2
 from vidio.read import OpenCVReader
-import os, glob
-from vidio.read import OpenCVReader
-from typing import List, Tuple
-import pathlib
 
 
-def get_clip(path, start, duration=60):
-    """
-    Read video clip from a file using OpenCV.
+def get_clip(path: str, start: int, duration: int = 60) -> np.ndarray:
+    """Read video clip from a file using OpenCV.
 
     Args:
-        path (str): Path to the video file.
-        start (int): Start frame index for the clip.
-        duration (int): Duration of the clip in frames.
+        path: Path to the video file.
+        start: Start frame index for the clip.
+        duration: Duration of the clip in frames.
 
     Returns:
-        np.ndarray: Video as array of frames.
+        Video as array of frames.
     """
     reader = OpenCVReader(path)
     clip = reader[start : start + duration]

--- a/video_embedding/io.py
+++ b/video_embedding/io.py
@@ -1,5 +1,3 @@
-"""Video reader for self-supervised learning."""
-
 import numpy as np
 from vidio.read import OpenCVReader
 

--- a/video_embedding/model.py
+++ b/video_embedding/model.py
@@ -1,34 +1,31 @@
-"""Core model definitions and utilities for video embedding and self-supervised learning."""
-
 import torch
 from typing import Tuple
 from torchvision import models
 
 
 class BarlowTwins(torch.nn.Module):
+    """Barlow Twins model for self-supervised learning of video representations.
+   
+    References:
+        - Paper: https://arxiv.org/abs/2103.03230
+        - Code: https://arxiv.org/abs/2104.02057
     """
-    Barlow Twins model for self-supervised learning of video representations. This model uses a backbone feature extractor and a projector to learn representations from augmented video sequences.
-
-    Args:
-        backbone: Backbone feature extractor.
-        feature_size: Size of the features extracted by the backbone.
-        projection_dim: Dimension of the projected features.
-        hidden_dim: Dimension of the hidden layer in the projector.
-        lamda: Regularization parameter for off-diagonal loss.
-
-    Returns:
-        Barlow Twins model instance.
-
-    Barlow Twins
-    Link: https://arxiv.org/abs/2104.02057
-    Implementation: https://arxiv.org/abs/2103.03230
-    """
-
     def __init__(
-        self, backbone, feature_size, projection_dim=1024, hidden_dim=1024, lamda=0.001
+        self, 
+        backbone: torch.nn.Module, 
+        feature_size: int, 
+        projection_dim: int = 1024, 
+        hidden_dim: int = 1024, 
+        lamda: float = 0.001
     ):
-        """Initialize the Barlow Twins model components."""
-
+        """
+        Args:
+            backbone: Feature extractor.
+            feature_size: Size of the features output by the backbone.
+            projection_dim: Output dimension of the projector MLP.
+            hidden_dim: Hidden layer dimension in the projector.
+            lamda: Weighting for the off-diagonal loss term.
+        """
         super().__init__()
         self.lamda = lamda
         self.backbone = backbone  # feature extractor
@@ -59,21 +56,16 @@ class BarlowTwins(torch.nn.Module):
 
 
 class Projector(torch.nn.Module):
-    """
-    Small feedforward neural model mapping high-dimensional features from the backbone into a space where Barlow Twins loss can be applied.
-
-    Args:
-        in_dim: Input dimension.
-        hidden_dim: Hidden dimension.
-        out_dim: Output dimension.
-
-    Returns:
-        Projector model.
-    """
-
-    def __init__(self, in_dim, hidden_dim=512, out_dim=128):
-        """Construct the projection head layers."""
-
+    """Maps high-dim features from backbone into a space where Barlow Twins loss can be applied."""
+    
+    def __init__(self, in_dim: int, hidden_dim: int = 512, out_dim: int = 128):
+        """
+        Args:
+            in_dim: Input dimension.
+            hidden_dim: Hidden dimension.
+            out_dim: Output dimension.
+            super().__init__()
+        """
         super().__init__()
 
         self.layer1 = torch.nn.Sequential(
@@ -100,8 +92,7 @@ class Projector(torch.nn.Module):
 
 
 def off_diagonal(x: torch.Tensor) -> torch.Tensor:
-    """
-    Extract the off-diagonal elements of a square matrix.
+    """Extract the off-diagonal elements of a square matrix.
 
     Args:
         x: Input tensor of shape ``(n, n)``.
@@ -114,8 +105,7 @@ def off_diagonal(x: torch.Tensor) -> torch.Tensor:
 
 
 def get_model(name: str = "s3d") -> Tuple[torch.nn.Module, int]:
-    """
-    Get a pre-trained video embedding model based on the specified name.
+    """Get a pre-trained video embedding model based on the specified name.
 
     Args:
         name: Name of the model to retrieve. Currently the only supported model is "s3d".

--- a/video_embedding/model.py
+++ b/video_embedding/model.py
@@ -1,20 +1,7 @@
 """Core model definitions and utilities for video embedding and self-supervised learning."""
 
-import numpy as np
 import torch
-import torch.nn.functional as F
-import albumentations as A
-import cv2
-from scipy.ndimage import gaussian_filter1d, median_filter
-import random
-from albumentations import ReplayCompose
-from vidio.read import OpenCVReader
-from torch.utils.data import DataLoader
-import os
-import tqdm
-from typing import Optional, Dict, Tuple
-from torch.optim import Optimizer
-from torch.optim.lr_scheduler import _LRScheduler, ReduceLROnPlateau
+from typing import Tuple
 from torchvision import models
 
 
@@ -23,14 +10,14 @@ class BarlowTwins(torch.nn.Module):
     Barlow Twins model for self-supervised learning of video representations. This model uses a backbone feature extractor and a projector to learn representations from augmented video sequences.
 
     Args:
-        backbone (torch.nn.Module): Backbone feature extractor.
-        feature_size (int): Size of the features extracted by the backbone.
-        projection_dim (int): Dimension of the projected features.
-        hidden_dim (int): Dimension of the hidden layer in the projector.
-        lamda (float): Regularization parameter for off-diagonal loss.
+        backbone: Backbone feature extractor.
+        feature_size: Size of the features extracted by the backbone.
+        projection_dim: Dimension of the projected features.
+        hidden_dim: Dimension of the hidden layer in the projector.
+        lamda: Regularization parameter for off-diagonal loss.
 
     Returns:
-        torch.nn.Module: Barlow Twins model.
+        Barlow Twins model instance.
 
     Barlow Twins
     Link: https://arxiv.org/abs/2104.02057
@@ -40,6 +27,8 @@ class BarlowTwins(torch.nn.Module):
     def __init__(
         self, backbone, feature_size, projection_dim=1024, hidden_dim=1024, lamda=0.001
     ):
+        """Initialize the Barlow Twins model components."""
+
         super().__init__()
         self.lamda = lamda
         self.backbone = backbone  # feature extractor
@@ -54,17 +43,17 @@ class BarlowTwins(torch.nn.Module):
 
 
     def forward(self, x1, x2):  # two augmented versions of the same input
+        """Compute Barlow Twins loss for a pair of augmented clips."""
+
         # pass both inputs through encoder
-        z1, z2 = self.encoder(x1), self.encoder(x2)  
+        z1, z2 = self.encoder(x1), self.encoder(x2)
 
         # compute cross-correlation matrix between normalized outputs
-        c = self.bn(z1).T @ self.bn(z2) 
+        c = self.bn(z1).T @ self.bn(z2)
         c.div_(z1.shape[0])
 
-        # apply BT loss; forces diagonal to be 1 causing same features to match
-        # penalizes non-diagonal elements thereby reducing redundancy between features
-        on_diag = (torch.diagonal(c).add_(-1).pow_(2).sum())  
-        off_diag = (off_diagonal(c).pow_(2).sum())  
+        on_diag = (torch.diagonal(c).add_(-1).pow_(2).sum())
+        off_diag = off_diagonal(c).pow_(2).sum()
         loss = on_diag + self.lamda * off_diag
         return loss
 
@@ -74,15 +63,17 @@ class Projector(torch.nn.Module):
     Small feedforward neural model mapping high-dimensional features from the backbone into a space where Barlow Twins loss can be applied.
 
     Args:
-        in_dim (int): Input dimension.
-        hidden_dim (int): Hidden dimension.
-        out_dim (int): Output dimension.
+        in_dim: Input dimension.
+        hidden_dim: Hidden dimension.
+        out_dim: Output dimension.
 
     Returns:
-        torch.nn.Module: Projector model.
+        Projector model.
     """
 
     def __init__(self, in_dim, hidden_dim=512, out_dim=128):
+        """Construct the projection head layers."""
+
         super().__init__()
 
         self.layer1 = torch.nn.Sequential(
@@ -100,36 +91,37 @@ class Projector(torch.nn.Module):
         )
 
     def forward(self, x):
+        """Forward pass of the projection head."""
+
         x = self.layer1(x)
         x = self.layer2(x)
         x = self.layer3(x)
         return x
 
 
-def off_diagonal(x):
+def off_diagonal(x: torch.Tensor) -> torch.Tensor:
     """
     Extract the off-diagonal elements of a square matrix.
 
     Args:
-        x (torch.Tensor): Input tensor of shape (n, n).
+        x: Input tensor of shape ``(n, n)``.
 
     Returns:
-        torch.Tensor: Off-diagonal elements of the input tensor, flattened.
+        Off-diagonal elements of the input tensor, flattened.
     """
     n, m = x.shape
     return x.flatten()[:-1].view(n - 1, n + 1)[:, 1:].flatten()
 
 
-def get_model(name: str = "s3d"):
+def get_model(name: str = "s3d") -> Tuple[torch.nn.Module, int]:
     """
     Get a pre-trained video embedding model based on the specified name.
 
     Args:
-        name (str): Name of the model to retrieve. Currently the only supported model is "s3d".
+        name: Name of the model to retrieve. Currently the only supported model is "s3d".
 
     Returns:
-        torch.nn.Module: Pre-trained video embedding model.
-        int: Dimension of the features extracted by the model.
+        Pre-trained video embedding model and the dimension of the extracted features.
     """
     if name == "s3d":
         model = models.video.s3d(weights=models.video.S3D_Weights.DEFAULT)

--- a/video_embedding/training.py
+++ b/video_embedding/training.py
@@ -6,16 +6,12 @@ import cv2
 import numpy as np
 import torch
 from torch.utils.data import Dataset, DataLoader
-from torch import nn
-from typing import Optional, Dict, Tuple
+from typing import Tuple
 from torch.optim import Optimizer
-from torch.optim.lr_scheduler import _LRScheduler, ReduceLROnPlateau
-from albumentations.pytorch import ToTensorV2
-from albumentations import ReplayCompose
+from torch.optim.lr_scheduler import _LRScheduler
 from .model import BarlowTwins, Projector, off_diagonal
 from vidio.read import OpenCVReader
 from .utils import transform_video, untransform_video
-import re
 
 
 class VideoClipDataset(Dataset):
@@ -29,6 +25,8 @@ class VideoClipDataset(Dataset):
         temporal_downsample=1,
         spatial_downsample=1,
     ):
+        """Initialize the dataset with a list of videos and augmentations."""
+
         self.temporal_downsample = temporal_downsample
         self.spatial_downsample = spatial_downsample
         self.video_paths = video_paths
@@ -43,9 +41,13 @@ class VideoClipDataset(Dataset):
         ).astype(int)
 
     def __len__(self):
+        """Return the number of possible clips."""
+
         return len(self.video_ixs)
 
     def __getitem__(self, idx):
+        """Load and augment a single clip."""
+
         video_ix = self.video_ixs[idx]
         frame_ix = self.frame_ixs[idx]
         reader = OpenCVReader(self.video_paths[video_ix])
@@ -80,16 +82,17 @@ def train(
     Trains a video embedding model using a Barlow Twins approach.
 
     Args:
-        learner (torch.nn.Module): Learner model returning loss.
-        model (torch.nn.Module): Backbone to extract features.
-        optimizer (torch.optim.Optimizer): Optimizer for the model.
-        scheduler (torch.optim.lr_scheduler._LRScheduler): Learning rate scheduler.
-        dataloader (DataLoader): DataLoader for training data.
-        start_epoch (int): Starting epoch for training.
-        epochs (int): Total number of epochs to train plus starting epoch.
-        steps_per_epoch (int): Number of steps per epoch.
-        checkpoint_dir (str): Directory to save checkpoints.
-        device (str, optional): Device to use for training. Defaults to "cuda".
+        learner: Learner model returning loss.
+        model: Backbone to extract features.
+        optimizer: Optimizer for the model.
+        scheduler: Learning rate scheduler.
+        dataloader: DataLoader for training data.
+        start_epoch: Starting epoch for training.
+        epochs: Total number of epochs to train plus starting epoch.
+        steps_per_epoch: Number of steps per epoch.
+        checkpoint_dir: Directory to save checkpoints.
+        loss_log_path: File path for saving the training loss curve.
+        device: Device to use for training.
     """
     print(f"Saving checkpoints to {checkpoint_dir}")
     os.makedirs(checkpoint_dir, exist_ok=True)
@@ -137,24 +140,30 @@ def train(
         )
 
 
-def load_from_checkpoint(checkpoint_path, model, learner, optimizer, scheduler):
+def load_from_checkpoint(
+    checkpoint_path: str,
+    model: torch.nn.Module,
+    learner: torch.nn.Module,
+    optimizer: Optimizer,
+    scheduler: _LRScheduler,
+) -> Tuple[torch.nn.Module, _LRScheduler, Optimizer, torch.nn.Module, int]:
     """
     Load model, learner, optimizer, and scheduler states from a checkpoint.
 
     Args:
-        checkpoint_path (str): Path to the checkpoint file.
-        model (torch.nn.Module): Model to load state into.
-        learner (torch.nn.Module): Learner to load state into.
-        optimizer (torch.optim.Optimizer): Optimizer to load state into.
-        scheduler (torch.optim.lr_scheduler._LRScheduler): Scheduler to load state into.
+        checkpoint_path: Path to the checkpoint file.
+        model: Model to load state into.
+        learner: Learner to load state into.
+        optimizer: Optimizer to load state into.
+        scheduler: Scheduler to load state into.
 
     Returns:
         Tuple containing
-            - learner (torch.nn.Module): Learner with loaded state.
-            - scheduler (torch.optim.lr_scheduler._LRScheduler): Scheduler with loaded state.
-            - optimizer (torch.optim.Optimizer): Optimizer with loaded state.
-            - model (torch.nn.Module): Model with loaded state.
-            - epoch (int): Epoch number from the checkpoint.
+            - learner with loaded state.
+            - scheduler with loaded state.
+            - optimizer with loaded state.
+            - model with loaded state.
+            - epoch number from the checkpoint.
     """
     checkpoint = torch.load(checkpoint_path)
     model.load_state_dict(checkpoint["model_state_dict"])
@@ -177,12 +186,12 @@ def save_model_info(
     Save model weights and experiment parameters together in a checkpoint file.
 
     Args:
-        model (torch.nn.Module): Model to save.
-        checkpoint_dir (str): Directory to save files.
-        epoch (int): Current epoch (used in checkpoint filename).
-        image_size (int): Image size.
-        duration (int): Clip duration.
-        temporal_downsample (int): Temporal downsample.
+        model: Model to save.
+        model_dir: Directory to save files.
+        epoch: Current epoch used in the checkpoint filename.
+        image_size: Image size.
+        duration: Clip duration.
+        temporal_downsample: Temporal downsample.
     """
     os.makedirs(model_dir, exist_ok=True)
     params = {

--- a/video_embedding/utils.py
+++ b/video_embedding/utils.py
@@ -1,5 +1,3 @@
-"""Transformation functions for video data."""
-
 import numpy as np
 import torch
 from typing import List, Tuple, Union, Optional
@@ -9,15 +7,10 @@ import tqdm
 
 
 def transform_video(video_array: np.ndarray) -> torch.Tensor:
-    """
-    - Normalize from 0-255 to 0-1
-    - Standardize channels using hard-coded mean and std
-    - Change channel order
-    - Convert to tensor
+    """Normalize video clip and reformat as torch tensor
 
     Args:
-        video_array: 4D or 5D array with shape ``([B], T, H, W, C)`` where ``B``
-            is the batch size.
+        video_array: 4D or 5D array of video frames with shape ``([B], T, H, W, C)``.
 
     Returns:
         Transformed video tensor with shape ``([B], C, T, H, W)``.
@@ -36,8 +29,7 @@ def transform_video(video_array: np.ndarray) -> torch.Tensor:
 
 
 def untransform_video(video_tensor: torch.Tensor) -> np.ndarray:
-    """
-    Inverts the transformations applied by the `transform_video` function.
+    """Invert the transformations applied by the `transform_video` function.
 
     Args:
         video_tensor: Transformed video tensor with shape ``([B], C, T, H, W)``.
@@ -65,8 +57,7 @@ def sample_timepoints(
     video_lengths: Optional[List[int]] = None,
     clip_size: int = 1,
 ) -> List[Tuple[str, int]]:
-    """
-    Uniformly sample timepoints (i.e. frame indexes) from an ensemble of videos.
+    """Uniformly sample frame indexes from an ensemble of videos.
 
     Args:
         video_paths: List of video file paths.

--- a/video_embedding/utils.py
+++ b/video_embedding/utils.py
@@ -2,17 +2,13 @@
 
 import numpy as np
 import torch
-import cv2
-from scipy.ndimage import gaussian_filter1d, median_filter
-import random
 from typing import List, Tuple, Union, Optional
-from albumentations.pytorch import ToTensorV2
-from albumentations import ReplayCompose
 from vidio.read import OpenCVReader
-import albumentations as A
+import imageio
+import tqdm
 
 
-def transform_video(video_array):
+def transform_video(video_array: np.ndarray) -> torch.Tensor:
     """
     - Normalize from 0-255 to 0-1
     - Standardize channels using hard-coded mean and std
@@ -20,11 +16,11 @@ def transform_video(video_array):
     - Convert to tensor
 
     Args:
-        video_array (numpy.ndarray): 4D or 5D array with shape ([B], T, H, W, C), where B is the
-        batch size, T is the number of frames, H is height, W is width, and C is channels (RGB).
+        video_array: 4D or 5D array with shape ``([B], T, H, W, C)`` where ``B``
+            is the batch size.
 
     Returns:
-        torch.Tensor: Transformed video tensor with shape ([B], C, T, H, W)
+        Transformed video tensor with shape ``([B], C, T, H, W)``.
     """
     video_array = video_array.astype(np.float32) / 255
 
@@ -39,16 +35,15 @@ def transform_video(video_array):
     return torch.from_numpy(video_array)
 
 
-def untransform_video(video_tensor):
+def untransform_video(video_tensor: torch.Tensor) -> np.ndarray:
     """
     Inverts the transformations applied by the `transform_video` function.
 
     Args:
-        video_tensor (torch.Tensor): Transformed video tensor with shape ([B], C, T, H, W), where B
-        is the batch size, C is channels (RGB), T is the frame count, H is height, and W is width.
+        video_tensor: Transformed video tensor with shape ``([B], C, T, H, W)``.
 
     Returns:
-        numpy.ndarray: 4D or 5D array of shape ([B], T, H, W, C) representing the original video(s).
+        4D or 5D array of shape ``([B], T, H, W, C)`` representing the original video(s).
     """
     video_array = video_tensor.numpy()
 
@@ -67,20 +62,20 @@ def untransform_video(video_tensor):
 def sample_timepoints(
     video_paths: List[str],
     num_samples: int,
-    video_lengths: List[int] = None,
+    video_lengths: Optional[List[int]] = None,
     clip_size: int = 1,
 ) -> List[Tuple[str, int]]:
     """
     Uniformly sample timepoints (i.e. frame indexes) from an ensemble of videos.
 
     Args:
-        video_paths: List of video file paths
-        num_samples: Number of timepoints to sample
-        video_lengths: Video lengths in frames. If None, lengths will be determined from files
-        clip_size: Ensure samples are at least this distance from the end of the video
+        video_paths: List of video file paths.
+        num_samples: Number of timepoints to sample.
+        video_lengths: Video lengths in frames. If ``None``, lengths are determined from files.
+        clip_size: Ensure samples are at least this distance from the end of the video.
 
     Returns:
-        List of tuples (video_path, timepoint)
+        List of tuples ``(video_path, timepoint)``.
     """
     if video_lengths is None:
         video_lengths = [len(OpenCVReader(p)) for p in video_paths]
@@ -100,16 +95,16 @@ def crop_video(
     crop_size: Union[int, Tuple[int, int]],
     quality: int = 5,
     constrain_track: Optional[bool] = True,
-):
+) -> None:
     """Crop a video around a time-varying centroid.
 
     Args:
         video_path: Path to the input video.
         cropped_video_path: Path to save the cropped video.
-        track: Array of shape (frames, 2) containing the crop centroid (x, y) for each frame.
-        crop_size: Size of the crop. If an integer is provided, it will crop a square of that size.
-        quality: Quality of the output video (passed to imageio.get_writer).
-        constrain_track: If True, ensures the cropped area does not exceed the video boundaries.
+        track: Array of shape ``(frames, 2)`` containing the crop centroid ``(x, y)`` for each frame.
+        crop_size: Size of the crop. If an integer is provided, it crops a square of that size.
+        quality: Quality of the output video passed to ``imageio.get_writer``.
+        constrain_track: If ``True``, ensures the cropped area does not exceed the video boundaries.
     """
     reader = OpenCVReader(video_path)
 

--- a/video_embedding/visualization.py
+++ b/video_embedding/visualization.py
@@ -5,29 +5,27 @@ import matplotlib.animation as animation
 from IPython.display import HTML
 import numpy as np
 from vidio.read import OpenCVReader
-import umap
-from sklearn.decomposition import PCA
 from typing import Optional, Dict, Tuple, Union, Iterable
 import matplotlib
-import imageio
-import tqdm
 import torch
 
 from .utils import sample_timepoints, untransform_video
 
 
-def play_videos(videos, rows, cols, inches=3):
+def play_videos(
+    videos: Iterable[np.ndarray], rows: int, cols: int, inches: int = 3
+) -> HTML:
     """
     Play multiple videos in a grid with specified rows and columns.
 
     Args:
-        videos: List of videos to display, each shaped as (frames, height, width, channels),
-        rows: Number of rows in the grid,
-        cols: Number of columns in the grid,
+        videos: List of videos to display, each shaped as ``(frames, height, width, channels)``.
+        rows: Number of rows in the grid.
+        cols: Number of columns in the grid.
         inches: Size of each subplot in inches.
 
     Returns:
-        HTML: HTML5 video player with the specified videos.
+        HTML5 video player with the specified videos.
     """
     num_videos = len(videos)
 
@@ -76,19 +74,17 @@ def play_videos(videos, rows, cols, inches=3):
 
 
 def crop_image(
-    image : np.ndarray,
-    centroid : Tuple[int, int],
-    crop_size : Union[int, Tuple[int, int]]
+    image: np.ndarray, centroid: Tuple[int, int], crop_size: Union[int, Tuple[int, int]]
 ) -> np.ndarray:
     """Crop an image around a centroid.
 
     Args:
-        image: Image to crop as array of shape (H, W, C) or (H, W).
-        centroid: Tuple of (x, y) coordinates representing the centroid around which to crop.
+        image: Image to crop as array of shape ``(H, W, C)`` or ``(H, W)``.
+        centroid: Tuple of ``(x, y)`` coordinates representing the centroid around which to crop.
         crop_size: Size of the crop. If an integer is provided, it will crop a square of that size.
 
     Returns:
-        np.ndarray: Cropped image as array of shape (H', W', C) or (H', W').
+        Cropped image as array of shape ``(H', W', C)`` or ``(H', W')``.
     """
     if isinstance(crop_size, tuple):
         w, h = crop_size
@@ -123,10 +119,10 @@ def inspect_crop_sizes(
         tracks: Map from video paths to tracks containing the animal's centroid at each frame.
         inner_crop_size: Size of the inner crop.
         outer_crop_size: Size of the outer crop.
-        n_examples (optional): Number of examples to visualize. Defaults to 4.
+        n_examples: Number of examples to visualize.
 
     Returns:
-        matplotlib.figure.Figure: Figure containing the visualizations.
+        Figure containing the visualizations.
     """
     video_paths = list(tracks.keys())
     samples = sample_timepoints(video_paths, n_examples)
@@ -162,11 +158,11 @@ def inspect_dataloader(
 
     Args:
         dataloader: Dataloader or iterable yielding batched pairs of augmented video clips.
-        num_samples: Number of samples (video clip pairs) to visualize.
+        num_samples: Number of samples to visualize.
         inches: Size of each subplot in inches.
-    
+
     Returns:
-        Ipython.display.HTML: HTML5 video player displaying the video clips.
+        HTML5 video player displaying the video clips.
     """
     x_one, x_two = next(iter(dataloader))
     if x_one.shape[0] < num_samples:

--- a/video_embedding/visualization.py
+++ b/video_embedding/visualization.py
@@ -1,5 +1,3 @@
-"""Methods for visualization of videos and video embeddings."""
-
 import matplotlib.pyplot as plt
 import matplotlib.animation as animation
 from IPython.display import HTML


### PR DESCRIPTION
## Summary
- drop unused imports across modules
- document dataset methods and augmentations
- describe training log path in `train`
- clarify Barlow Twins and projector internals
- ensure files end with a newline

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683f483d02cc832ba8e7ed971e307a34